### PR TITLE
Implemented read rules from files instead of assets

### DIFF
--- a/neat-form-core/src/main/java/com/nerdstone/neatformcore/form/json/JsonFormBuilder.kt
+++ b/neat-form-core/src/main/java/com/nerdstone/neatformcore/form/json/JsonFormBuilder.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.view.View
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
 import com.nerdstone.neatformcore.datasource.AssetFile
 import com.nerdstone.neatformcore.domain.builders.FormBuilder
 import com.nerdstone.neatformcore.domain.model.NForm
@@ -26,7 +25,6 @@ import com.nerdstone.neatformcore.views.containers.VerticalRootView
 import com.nerdstone.neatformcore.views.handlers.ViewDispatcher
 import com.nerdstone.neatformcore.views.widgets.*
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancelChildren
 import timber.log.Timber
 import java.lang.ref.WeakReference
 import kotlin.reflect.KClass

--- a/neat-form-core/src/main/java/com/nerdstone/neatformcore/rules/RulesFactory.kt
+++ b/neat-form-core/src/main/java/com/nerdstone/neatformcore/rules/RulesFactory.kt
@@ -52,7 +52,7 @@ class RulesFactory : RuleListener {
     override fun afterEvaluate(rule: Rule?, facts: Facts?, evaluationResult: Boolean) =
             rulesHandler.updateSkipLogicFactAfterEvaluate(evaluationResult, rule, facts)
 
-    fun readRulesFromFile(
+/*    fun readRulesFromFile(
             context: Context, filePath: String, rulesFileType: RulesFileType
     ) {
         if (allRules == null) {
@@ -64,6 +64,23 @@ class RulesFactory : RuleListener {
             allRules = mvelRuleFactory.createRules(
                     BufferedReader(
                             InputStreamReader(AssetFile.openFileAsset(context, filePath))
+                    )
+            )
+        }
+    }*/
+
+    fun readRulesFromFile(
+            context: Context, fileName: String, rulesFileType: RulesFileType
+    ) {
+        if (allRules == null) {
+            val mvelRuleFactory: MVELRuleFactory = when (rulesFileType) {
+                RulesFileType.JSON -> MVELRuleFactory(JsonRuleDefinitionReader())
+                RulesFileType.YAML -> MVELRuleFactory(YamlRuleDefinitionReader())
+            }
+
+            allRules = mvelRuleFactory.createRules(
+                    BufferedReader(
+                            InputStreamReader(context.openFileInput(fileName))
                     )
             )
         }


### PR DESCRIPTION
Since the RulesFactory reads from fileName name now instead of file path, I used this:

{
  "form": "Repair BoreHole Form",
  "rules_file": "everflow_rules.yml",
  "steps": [
    {

Still liable to testing
thank you