### PR TITLE
Implementing edit text mask

### DIFF
--- a/neat-form-core/build.gradle
+++ b/neat-form-core/build.gradle
@@ -92,6 +92,10 @@ dependencies {
     api 'org.jeasy:easy-rules-mvel:3.3.0'
     api 'com.google.code.gson:gson:2.8.6'
     api 'com.github.chivorns:smartmaterialspinner:1.2.1'
+    api ('io.github.softmedtanzania:maskededittext:1.0.5'){
+        transitive = true
+        exclude group: 'androidx.appcompat', module: 'appcompat'
+    }
 
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.robolectric:robolectric:4.4'

--- a/neat-form-core/src/main/java/com/nerdstone/neatformcore/form/json/JsonFormBuilder.kt
+++ b/neat-form-core/src/main/java/com/nerdstone/neatformcore/form/json/JsonFormBuilder.kt
@@ -192,6 +192,7 @@ class JsonFormBuilder() : FormBuilder {
 
     override fun registerViews() {
         registeredViews[ViewType.EDIT_TEXT] = EditTextNFormView::class
+        registeredViews[ViewType.MASKED_EDIT_TEXT] = MaskedEditTextNFormView::class
         registeredViews[ViewType.TEXT_INPUT_EDIT_TEXT] = TextInputEditTextNFormView::class
         registeredViews[ViewType.NUMBER_SELECTOR] = NumberSelectorNFormView::class
         registeredViews[ViewType.SPINNER] = SpinnerNFormView::class

--- a/neat-form-core/src/main/java/com/nerdstone/neatformcore/utils/Constants.kt
+++ b/neat-form-core/src/main/java/com/nerdstone/neatformcore/utils/Constants.kt
@@ -23,6 +23,7 @@ object Constants {
         const val SPINNER = "spinner"
         const val EDIT_TEXT = "edit_text"
         const val TEXT_INPUT_EDIT_TEXT = "text_input_edit_text"
+        const val MASKED_EDIT_TEXT = "masked_edit_text"
         const val MULTI_CHOICE_CHECKBOX = "multi_choice_checkbox"
         const val CHECKBOX = "checkbox"
         const val RADIO_GROUP = "radio_group"

--- a/neat-form-core/src/main/java/com/nerdstone/neatformcore/views/builders/MaskedEditTextViewBuilder.kt
+++ b/neat-form-core/src/main/java/com/nerdstone/neatformcore/views/builders/MaskedEditTextViewBuilder.kt
@@ -39,7 +39,7 @@ open class MaskedEditTextViewBuilder(final override val nFormView: NFormView) : 
     private fun formatHintForRequiredFields() {
         with(editTextNFormView) {
             if (!viewProperties.requiredStatus.isNullOrBlank() && isFieldRequired()) {
-                hint = hint.toString().addRedAsteriskSuffix()
+                floatingLabelText = floatingLabelText.toString().addRedAsteriskSuffix()
             }
         }
     }
@@ -65,9 +65,7 @@ open class MaskedEditTextViewBuilder(final override val nFormView: NFormView) : 
                 }
                 EditTextProperties.HINT.name -> {
                     floatingLabelText = attribute.value.toString()
-                    if (isFieldRequired()) {
-                        floatingLabelText = floatingLabelText.toString().addRedAsteriskSuffix()
-                    }
+                    formatHintForRequiredFields()
                 }
                 EditTextProperties.PADDING.name -> {
                     val value = editTextNFormView.context.pxToDp(
@@ -83,7 +81,7 @@ open class MaskedEditTextViewBuilder(final override val nFormView: NFormView) : 
                 }
                 EditTextProperties.INPUT_TYPE.name -> {
                     getSupportedEditTextTypes()[attribute.value.toString()]
-                        ?.also { inputType = it }
+                        ?.also { setRawInputType(it) }
                 }
                 EditTextProperties.BACKGROUND.name -> {
                     resourcesMap[attribute.value.toString()]?.let { setBackgroundResource(it) }

--- a/neat-form-core/src/main/java/com/nerdstone/neatformcore/views/builders/MaskedEditTextViewBuilder.kt
+++ b/neat-form-core/src/main/java/com/nerdstone/neatformcore/views/builders/MaskedEditTextViewBuilder.kt
@@ -1,0 +1,95 @@
+package com.nerdstone.neatformcore.views.builders
+
+import android.text.SpannableStringBuilder
+import androidx.core.widget.TextViewCompat
+import com.nerdstone.neatformcore.R
+import com.nerdstone.neatformcore.domain.builders.ViewBuilder
+import com.nerdstone.neatformcore.domain.view.NFormView
+import com.nerdstone.neatformcore.utils.*
+import com.nerdstone.neatformcore.views.widgets.MaskedEditTextNFormView
+import java.util.*
+
+open class MaskedEditTextViewBuilder(final override val nFormView: NFormView) : ViewBuilder {
+
+    private val editTextNFormView = nFormView as MaskedEditTextNFormView
+
+    override val acceptedAttributes = EditTextProperties::class.java.convertEnumToSet()
+
+    override lateinit var resourcesMap: MutableMap<String, Int>
+
+    enum class EditTextProperties {
+        HINT, PADDING, TEXT_SIZE, TEXT, INPUT_TYPE, BACKGROUND, MASK, ALLOWED_CHARS, MASK_HINT
+    }
+
+    override fun buildView() {
+        //Hide keyboard when focus is lost
+        editTextNFormView.apply {
+            applyViewAttributes(
+                acceptedAttributes,
+                this@MaskedEditTextViewBuilder::setViewProperties
+            )
+            setOnFocusChangeListener { _, hasFocus ->
+                if (!hasFocus) {
+                    editTextNFormView.hideSoftKeyBoard()
+                }
+            }
+        }
+    }
+
+    private fun formatHintForRequiredFields() {
+        with(editTextNFormView) {
+            if (!viewProperties.requiredStatus.isNullOrBlank() && isFieldRequired()) {
+                hint = hint.toString().addRedAsteriskSuffix()
+            }
+        }
+    }
+
+    override fun setViewProperties(attribute: Map.Entry<String, Any>) {
+        editTextNFormView.apply {
+            if (viewProperties.getResourceFromAttribute().isNullOrEmpty())
+                TextViewCompat.setTextAppearance(editTextNFormView, R.style.editTextStyle)
+
+
+            when (attribute.key.toUpperCase(Locale.getDefault())) {
+                EditTextProperties.MASK_HINT.name -> {
+                    hint = SpannableStringBuilder(attribute.value as String)
+                }
+            }
+
+            when (attribute.key.toUpperCase(Locale.getDefault())) {
+                EditTextProperties.MASK.name -> {
+                    mask = attribute.value.toString()
+                }
+                EditTextProperties.ALLOWED_CHARS.name -> {
+                    allowedChars = attribute.value.toString()
+                }
+                EditTextProperties.HINT.name -> {
+                    floatingLabelText = attribute.value.toString()
+                    if (isFieldRequired()) {
+                        floatingLabelText = floatingLabelText.toString().addRedAsteriskSuffix()
+                    }
+                }
+                EditTextProperties.PADDING.name -> {
+                    val value = editTextNFormView.context.pxToDp(
+                        (attribute.value as String).toFloat(),
+                    )
+                    setPadding(value, value, value, value)
+                }
+                EditTextProperties.TEXT_SIZE.name ->
+                    textSize = (attribute.value as String).toFloat()
+
+                EditTextProperties.TEXT.name -> {
+                    setText(attribute.value.toString())
+                }
+                EditTextProperties.INPUT_TYPE.name -> {
+                    getSupportedEditTextTypes()[attribute.value.toString()]
+                        ?.also { inputType = it }
+                }
+                EditTextProperties.BACKGROUND.name -> {
+                    resourcesMap[attribute.value.toString()]?.let { setBackgroundResource(it) }
+                }
+
+            }
+        }
+    }
+}

--- a/neat-form-core/src/main/java/com/nerdstone/neatformcore/views/handlers/ViewVisibilityChangeHandler.kt
+++ b/neat-form-core/src/main/java/com/nerdstone/neatformcore/views/handlers/ViewVisibilityChangeHandler.kt
@@ -5,6 +5,7 @@ import com.nerdstone.neatformcore.domain.listeners.VisibilityChangeListener
 import com.nerdstone.neatformcore.domain.view.NFormView
 import com.nerdstone.neatformcore.utils.animateView
 import com.nerdstone.neatformcore.utils.isNotNull
+import com.nerdstone.neatformcore.views.widgets.MaskedEditTextNFormView
 
 object ViewVisibilityChangeHandler : VisibilityChangeListener {
 
@@ -17,8 +18,12 @@ object ViewVisibilityChangeHandler : VisibilityChangeListener {
                 ) {
                     resetValueWhenHidden()
                 }
+                if (this is MaskedEditTextNFormView && visibility == View.GONE && viewDetails.value.isNotNull()) {
+                    resetValueWhenHidden()
+                }
                 trackRequiredField()
             }
+
         }
     }
 }

--- a/neat-form-core/src/main/java/com/nerdstone/neatformcore/views/widgets/MaskedEditTextNFormView.kt
+++ b/neat-form-core/src/main/java/com/nerdstone/neatformcore/views/widgets/MaskedEditTextNFormView.kt
@@ -1,0 +1,86 @@
+package com.nerdstone.neatformcore.views.widgets
+
+import android.content.Context
+import android.util.AttributeSet
+import com.nerdstone.neatformcore.R
+import com.nerdstone.neatformcore.domain.listeners.DataActionListener
+import com.nerdstone.neatformcore.domain.listeners.VisibilityChangeListener
+import com.nerdstone.neatformcore.domain.model.NFormViewDetails
+import com.nerdstone.neatformcore.domain.model.NFormViewProperty
+import com.nerdstone.neatformcore.domain.view.FormValidator
+import com.nerdstone.neatformcore.domain.view.NFormView
+import com.nerdstone.neatformcore.utils.handleRequiredStatus
+import com.nerdstone.neatformcore.utils.removeAsterisk
+import com.nerdstone.neatformcore.utils.setReadOnlyState
+import com.nerdstone.neatformcore.views.builders.MaskedEditTextViewBuilder
+import com.nerdstone.neatformcore.views.handlers.ViewVisibilityChangeHandler
+import com.rengwuxian.materialedittext.MaterialEditText
+import io.github.softmedtanzania.MaskedEditText
+
+
+class MaskedEditTextNFormView : MaskedEditText, NFormView {
+
+    override lateinit var viewProperties: NFormViewProperty
+    override lateinit var formValidator: FormValidator
+    override var dataActionListener: DataActionListener? = null
+    override var visibilityChangeListener: VisibilityChangeListener? = ViewVisibilityChangeHandler
+    override val viewBuilder = MaskedEditTextViewBuilder(this)
+    override var viewDetails = NFormViewDetails(this)
+    override var initialValue: Any? = null
+
+    constructor(context: Context) : super(context, null) {
+        setFloatingLabel(MaterialEditText.FLOATING_LABEL_NORMAL)
+        floatingLabelTextSize = resources.getDimension(R.dimen.default_text_size).toInt()
+        floatingLabelTextColor = resources.getColor(R.color.colorBlack)
+        invalidate()
+    }
+
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+
+    override fun onTextChanged(
+        text: CharSequence, start: Int, lengthBefore: Int,
+        lengthAfter: Int
+    ) {
+        super.onTextChanged(text, start, lengthBefore, lengthAfter)
+        this.dataActionListener?.also {
+            if (rawText.isNotEmpty()) {
+                this.viewDetails.value =
+                    text.toString().removeAsterisk()
+
+            } else {
+                this.viewDetails.value = null
+            }
+            it.onPassData(this.viewDetails)
+        }
+    }
+
+    override fun resetValueWhenHidden() = setText("")
+
+    override fun trackRequiredField() = handleRequiredStatus()
+
+    override fun validateValue(): Boolean {
+        val validationPair = formValidator.validateField(this)
+        if (!validationPair.first) {
+            this.error = validationPair.second
+            error = validationPair.second
+            isAutoValidate = true
+            errorColor = resources.getColor(R.color.colorRed)
+            floatingLabelTextColor = resources.getColor(R.color.colorRed)
+        } else {
+            this.error = null
+            floatingLabelTextColor = resources.getColor(R.color.colorBlack)
+        }
+        return validationPair.first
+    }
+
+    override fun setValue(value: Any, enabled: Boolean) {
+        initialValue = value
+        setText(value.toString())
+        setReadOnlyState(enabled)
+    }
+
+    override fun setVisibility(visibility: Int) {
+        super.setVisibility(visibility)
+        visibilityChangeListener?.onVisibilityChanged(this, visibility)
+    }
+}

--- a/neat-form-core/src/main/java/com/nerdstone/neatformcore/views/widgets/MaskedEditTextNFormView.kt
+++ b/neat-form-core/src/main/java/com/nerdstone/neatformcore/views/widgets/MaskedEditTextNFormView.kt
@@ -30,8 +30,12 @@ class MaskedEditTextNFormView : MaskedEditText, NFormView {
 
     constructor(context: Context) : super(context, null) {
         setFloatingLabel(MaterialEditText.FLOATING_LABEL_NORMAL)
+        setPrimaryColor(R.color.colorBlack)
+        isFloatingLabelAlwaysShown = true
         floatingLabelTextSize = resources.getDimension(R.dimen.default_text_size).toInt()
         floatingLabelTextColor = resources.getColor(R.color.colorBlack)
+        focusFraction=1F
+        setMetHintTextColor(R.color.colorBlack)
         invalidate()
     }
 

--- a/neat-form-core/src/test/java/com/nerdstone/neatformcore/robolectric/builders/MaskedEditTextViewBuilderTest.kt
+++ b/neat-form-core/src/test/java/com/nerdstone/neatformcore/robolectric/builders/MaskedEditTextViewBuilderTest.kt
@@ -62,6 +62,19 @@ class MaskedEditTextViewBuilderTest : BaseJsonViewBuilderTest() {
     }
 
     @Test
+    fun `Should set only allow the allowed characters on the field `() {
+        val mask = "##"
+        val allowedChars = "12"
+        viewProperty.viewAttributes = hashMapOf("mask" to mask,"text" to "13242")
+        maskedEditTextNFormView.allowedChars = allowedChars
+        maskedEditTextViewBuilder.buildView()
+        Assert.assertTrue(
+            maskedEditTextNFormView.text.toString().isNotEmpty() &&
+                    maskedEditTextNFormView.text.toString() == "12"
+        )
+    }
+
+    @Test
     fun `Should set mask hint on the field `() {
         val hint = "1234"
         viewProperty.viewAttributes = hashMapOf("mask_hint" to hint)
@@ -82,8 +95,8 @@ class MaskedEditTextViewBuilderTest : BaseJsonViewBuilderTest() {
 
     @Test
     fun `Should reset the MaskedEditText value when visibility is gone`() {
-       maskedEditTextNFormView.mask = "##-##"
-        maskedEditTextNFormView.setValue("1122")
+        viewProperty.viewAttributes = hashMapOf("mask" to "##-##","text" to "1122" )
+        maskedEditTextViewBuilder.buildView()
         maskedEditTextNFormView.visibility = View.GONE
         Assert.assertTrue(maskedEditTextNFormView.text.toString().isEmpty())
         Assert.assertTrue(maskedEditTextNFormView.mask.toString() == "##-##")
@@ -91,9 +104,7 @@ class MaskedEditTextViewBuilderTest : BaseJsonViewBuilderTest() {
 
     @Test
     fun `Should set Text to the MaskedEditText`() {
-        //mask should be set before setting text
-        maskedEditTextNFormView.mask = "##-##"
-        maskedEditTextNFormView.setText("1122")
+        viewProperty.viewAttributes = hashMapOf("mask" to "##-##","text" to "1122" )
         maskedEditTextViewBuilder.buildView()
         Assert.assertFalse(maskedEditTextNFormView.text.toString().isEmpty())
     }

--- a/neat-form-core/src/test/java/com/nerdstone/neatformcore/robolectric/builders/MaskedEditTextViewBuilderTest.kt
+++ b/neat-form-core/src/test/java/com/nerdstone/neatformcore/robolectric/builders/MaskedEditTextViewBuilderTest.kt
@@ -134,7 +134,7 @@ class MaskedEditTextViewBuilderTest : BaseJsonViewBuilderTest() {
         maskedEditTextNFormView.mask = "(###)-###-###"
         maskedEditTextNFormView.setText("012345678")
         maskedEditTextViewBuilder.buildView()
-        Assert.assertTrue( maskedEditTextNFormView.text.toString()==("(012)-345-678"))
+        Assert.assertTrue( maskedEditTextNFormView.text.toString()=="(012)-345-678")
     }
 
     @Test

--- a/neat-form-core/src/test/java/com/nerdstone/neatformcore/robolectric/builders/MaskedEditTextViewBuilderTest.kt
+++ b/neat-form-core/src/test/java/com/nerdstone/neatformcore/robolectric/builders/MaskedEditTextViewBuilderTest.kt
@@ -1,0 +1,151 @@
+package com.nerdstone.neatformcore.robolectric.builders
+
+import android.text.InputType
+import android.view.View
+import com.nerdstone.neatformcore.domain.model.NFormFieldValidation
+import com.nerdstone.neatformcore.domain.model.NFormViewProperty
+import com.nerdstone.neatformcore.utils.setupView
+import com.nerdstone.neatformcore.views.builders.MaskedEditTextViewBuilder
+import com.nerdstone.neatformcore.views.widgets.MaskedEditTextNFormView
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class MaskedEditTextViewBuilderTest : BaseJsonViewBuilderTest() {
+
+    private val viewProperty = spyk(NFormViewProperty())
+    private val maskedEditTextNFormView = MaskedEditTextNFormView(activity.get())
+    private val maskedEditTextViewBuilder = spyk(MaskedEditTextViewBuilder(maskedEditTextNFormView))
+
+    @Before
+    fun `Before doing anything else`() {
+        viewProperty.name = "name"
+        viewProperty.type = "masked_edit_text"
+        //Set MaskedEditText properties and assign MaskedEditText view builder
+        maskedEditTextNFormView.viewProperties = viewProperty
+        maskedEditTextNFormView.setupView(viewProperty, formBuilder)
+    }
+
+    @Test
+    fun `Should set floating label`() {
+        val hint = "Am a hint"
+        viewProperty.viewAttributes = hashMapOf("hint" to hint)
+        maskedEditTextViewBuilder.buildView()
+        Assert.assertTrue(maskedEditTextNFormView.floatingLabelText.isNotEmpty() && maskedEditTextNFormView.floatingLabelText.toString() == hint)
+    }
+
+    @Test
+    fun `Should set required on floating label `() {
+        val hint = "Am a required field"
+        viewProperty.viewAttributes = hashMapOf("hint" to hint)
+        viewProperty.requiredStatus = "yes:Am required"
+        maskedEditTextViewBuilder.buildView()
+        Assert.assertTrue(
+            maskedEditTextNFormView.floatingLabelText.isNotEmpty() && maskedEditTextNFormView.floatingLabelText.endsWith(
+                "*"
+            )
+        )
+    }
+
+    @Test
+    fun `Should set mask on the field `() {
+        val mask = "##-##"
+        viewProperty.viewAttributes = hashMapOf("mask" to mask)
+        maskedEditTextViewBuilder.buildView()
+        Assert.assertTrue(
+            maskedEditTextNFormView.mask.toString().isNotEmpty() &&
+                    maskedEditTextNFormView.mask.toString() == mask
+        )
+    }
+
+    @Test
+    fun `Should set mask hint on the field `() {
+        val hint = "1234"
+        viewProperty.viewAttributes = hashMapOf("mask_hint" to hint)
+        maskedEditTextViewBuilder.buildView()
+        Assert.assertTrue(
+            maskedEditTextNFormView.hint.toString().isNotEmpty() &&
+                    maskedEditTextNFormView.hint.toString() == hint
+        )
+    }
+
+    @Test
+    fun `Should set padding on MaskedEditText `() {
+        viewProperty.viewAttributes = hashMapOf("padding" to "12")
+        maskedEditTextViewBuilder.buildView()
+        Assert.assertTrue(maskedEditTextNFormView.paddingBottom == 12 && maskedEditTextNFormView.paddingTop == 12)
+        Assert.assertTrue(maskedEditTextNFormView.paddingEnd == 12 && maskedEditTextNFormView.paddingStart == 12)
+    }
+
+    @Test
+    fun `Should reset the MaskedEditText value when visibility is gone`() {
+       maskedEditTextNFormView.mask = "##-##"
+        maskedEditTextNFormView.setValue("1122")
+        maskedEditTextNFormView.visibility = View.GONE
+        Assert.assertTrue(maskedEditTextNFormView.text.toString().isEmpty())
+        Assert.assertTrue(maskedEditTextNFormView.mask.toString() == "##-##")
+    }
+
+    @Test
+    fun `Should set Text to the MaskedEditText`() {
+        //mask should be set before setting text
+        maskedEditTextNFormView.mask = "##-##"
+        maskedEditTextNFormView.setText("1122")
+        maskedEditTextViewBuilder.buildView()
+        Assert.assertFalse(maskedEditTextNFormView.text.toString().isEmpty())
+    }
+
+    @Test
+    fun `Should validate MaskedEditText value`() {
+        val validation = NFormFieldValidation()
+        validation.condition =
+            "value.matches(\"(\\\\d{2}-\\\\d{2}-\\\\d{4}-\\\\d{6})?\")"
+        validation.message = "Please enter a valid CTC Number"
+
+        viewProperty.validations = arrayListOf(validation)
+        viewProperty.requiredStatus = "yes:Am required"
+        maskedEditTextViewBuilder.buildView()
+        maskedEditTextNFormView.mask = "##-##-####-######"
+        maskedEditTextNFormView.setText("12345678912345")
+        Assert.assertTrue(maskedEditTextNFormView.validateValue())
+
+
+        maskedEditTextNFormView.setText("12345678912")
+        Assert.assertFalse(maskedEditTextNFormView.validateValue())
+        Assert.assertTrue(maskedEditTextNFormView.error == "Please enter a valid CTC Number")
+    }
+
+    @Test
+    fun `Should check if mask is added to input`(){
+        maskedEditTextNFormView.mask = "(###)-###-###"
+        maskedEditTextNFormView.setText("012345678")
+        maskedEditTextViewBuilder.buildView()
+        Assert.assertTrue( maskedEditTextNFormView.text.toString()==("(012)-345-678"))
+    }
+
+    @Test
+    fun `Should apply the provided input type`() {
+        val hint = "Am a hint"
+        viewProperty.viewAttributes = hashMapOf("mask" to "###", "hint" to hint, "input_type" to "phone")
+        maskedEditTextViewBuilder.buildView()
+        Assert.assertEquals(maskedEditTextNFormView.inputType, InputType.TYPE_CLASS_PHONE)
+    }
+
+    @Test
+    fun `Should set value to the MaskedEditText when provided`() {
+        maskedEditTextViewBuilder.buildView()
+        val textValue = "0723721920"
+        maskedEditTextNFormView.mask = "##########"
+        maskedEditTextNFormView.setValue(textValue)
+        Assert.assertEquals(maskedEditTextNFormView.initialValue, textValue)
+        Assert.assertEquals(maskedEditTextNFormView.text.toString(), "0723721920")
+    }
+
+    @After
+    fun `After everything else`() {
+        unmockkAll()
+    }
+}

--- a/sample/src/main/assets/rules/yml/hiv_registration_form_rules.yml
+++ b/sample/src/main/assets/rules/yml/hiv_registration_form_rules.yml
@@ -1,0 +1,28 @@
+---
+name: "hiv_registration_date_calculation"
+description: "calculating the hiv registration date"
+priority: 1
+condition: "true"
+actions:
+  - "hiv_registration_date_calculation = System.currentTimeMillis()"
+---
+name: "client_hiv_status_during_registration_calculation"
+description: "calculating client_hiv_status_during_registration"
+priority: 1
+condition: "true"
+actions:
+  - "client_hiv_status_during_registration_calculation = 'Positive'"
+---
+name: "test_results_calculation"
+description: "calculating test_results"
+priority: 1
+condition: "true"
+actions:
+  - "test_results_calculation = 'Positive'"
+---
+name: "place_where_test_was_conducted_other_visibility"
+description: "Specify other place where the test was conducted"
+priority: 1
+condition: "place_where_test_was_conducted['other'] != null"
+actions:
+  - "place_where_test_was_conducted_other_visibility =  true"

--- a/sample/src/main/assets/sample/hiv_registration.json
+++ b/sample/src/main/assets/sample/hiv_registration.json
@@ -1,0 +1,271 @@
+{
+  "form": "HIV Registration form",
+  "count": "1",
+  "encounter_type": "HIV Registration",
+  "entity_id": "",
+  "relational_id": "",
+  "rules_file": "rules/yml/hiv_registration_form_rules.yml",
+  "metadata": {
+    "start": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "start",
+      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "end": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "end",
+      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "today": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "encounter",
+      "openmrs_entity_id": "encounter_date"
+    },
+    "deviceid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "deviceid",
+      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "subscriberid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "subscriberid",
+      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "simserial": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "simserial",
+      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "phonenumber": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "phonenumber",
+      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "encounter_location": "",
+    "look_up": {
+      "entity_id": "",
+      "value": ""
+    }
+  },
+  "steps": [
+    {
+      "title": "HIV Clients Registration form",
+      "fields": [
+        {
+          "name": "new_or_current_hiv_client",
+          "type": "radio_group",
+          "properties": {
+            "text": "Is the registered client a new HIV Client or an existing HIV Client?"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "new_or_current_hiv_client",
+            "openmrs_entity_parent": ""
+          },
+          "options": [
+            {
+              "name": "new",
+              "text": "New HIV client",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "new",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "existing",
+              "text": "Existing HIV Client",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "existing",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please select the answer"
+        },
+        {
+          "name": "place_where_test_was_conducted",
+          "type": "radio_group",
+          "properties": {
+            "text": "Where was the test conducted?"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "place_where_test_was_conducted",
+            "openmrs_entity_parent": ""
+          },
+          "options": [
+            {
+              "name": "tb_clinic_outpatient",
+              "text": "Tuberculosis clinic (out patient)",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "tb_clinic_outpatient",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "sexual_transmitted_diseases_clinic",
+              "text": "Sexual transmitted diseases clinic",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "sexual_transmitted_diseases_clinic",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "outpatient_department",
+              "text": "Outpatient department",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "outpatient_department",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "inpatient_department",
+              "text": "Inpatient department",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "inpatient_department",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "blood_transfusion_service",
+              "text": "Blood transfusion service",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "blood_transfusion_service",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "home_selftest_service",
+              "text": "Home selftest service",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "home_selftest_service",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "voluntary_patients",
+              "text": "Voluntary patients",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "voluntary_patients",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "family_planning_clinic",
+              "text": "Family planning clinic",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "family_planning_clinic",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "ctc",
+              "text": "CTC",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "ctc",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "men_circumcision",
+              "text": "Men circumcision",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "men_circumcision",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "outreach_services",
+              "text": "Outreach services",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "outreach_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "reproductive_an_child_health",
+              "text": "Reproductive and child health",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "reproductive_an_child_health",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "other",
+              "text": "Other",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "other",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please select the answer"
+        },
+        {
+          "name": "place_where_test_was_conducted_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Other (Specify)",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "place_where_test_was_conducted_other",
+            "openmrs_entity_parent": ""
+          },
+          "required_status": "true:Please specify the place where the test was conducted",
+          "subjects": "place_where_test_was_conducted:map"
+        },
+        {
+          "name": "ctc_number",
+          "type": "masked_edit_text",
+          "properties": {
+            "hint": "CTC Number e.g 12-34-5678-912345",
+            "mask": "##-##-####-######",
+            "mask_hint": "12345678912345",
+            "allowed_chars": "1234567890-",
+            "type": "Clinic of Treatment and Care registration number (CTC Number)"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "ctc_number",
+            "openmrs_entity_parent": ""
+          },
+          "validation": [
+            {
+              "condition": "value.matches(\"(\\\\d{2}-\\\\d{2}-\\\\d{4}-\\\\d{6})?\")",
+              "message": "CTC Number should be of the format (XX-XX-XXXX-XXXXXX)."
+            }
+          ],
+          "required_status": "yes:Please specify client's CTC number",
+          "dependent_calculations": [
+            "hiv_registration_date",
+            "client_hiv_status_during_registration",
+            "test_results"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/sample/src/main/java/com/nerdstone/neatform/MainActivity.kt
+++ b/sample/src/main/java/com/nerdstone/neatform/MainActivity.kt
@@ -60,6 +60,11 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
                     filePath = "sample/tb_followup_visit.json"
                 ),
                 FormData(
+                    formTitle = "HIV Registration",
+                    formCategory = FormType.jsonFromEmbeddedDefault,
+                    filePath = "sample/hiv_registration.json"
+                ),
+                FormData(
                     formTitle = "Default Embedded Form",
                     formCategory = FormType.jsonFromEmbeddedDefault,
                     filePath = "sample/sample_one_form.json"


### PR DESCRIPTION
Added an edit text mask, which helps in inputting numbers with standardized formats.

**example**:
  1. Inputting a phone number with format +255(0)XXX-XXXXXX
  2. Inputting a passport number

This fix helps to define the mask on a new input field 